### PR TITLE
Fix ctags file generation for VimL

### DIFF
--- a/autoload/neoinclude.vim
+++ b/autoload/neoinclude.vim
@@ -146,7 +146,7 @@ function! neoinclude#initialize() abort "{{{
         \ '_', '')
   call neoinclude#util#set_default_dictionary(
         \ 'g:neoinclude#_ctags_arguments', 'vim',
-        \ '--language-force=vim --extra=fq --fields=afmiKlnsStz ' .
+        \ '--language-force=vim --extra=fq --fields=afmiKlnsStz --vim-kinds=-f '.
         \ "--regex-vim='/function!? ([a-z#:_0-9A-Z]+)/\\1/function/'")
   if neoinclude#util#is_mac()
     call neoinclude#util#set_default_dictionary(

--- a/autoload/neoinclude.vim
+++ b/autoload/neoinclude.vim
@@ -147,7 +147,9 @@ function! neoinclude#initialize() abort "{{{
   call neoinclude#util#set_default_dictionary(
         \ 'g:neoinclude#_ctags_arguments', 'vim',
         \ '--language-force=vim --extra=fq --fields=afmiKlnsStz --vim-kinds=-f '.
-        \ "--regex-vim='/function!? ([a-z#:_0-9A-Z]+)/\\1/function/'")
+        \ '--regex-vim=''/function!?[ \t]+'.
+        \ '(([bwtglsa]:)?\w+(\.\w+)+|(g:)?([A-Z]\w*|\w+(#\w+)+)|s:\w+)'.
+        \ '[ \t]*\(/\1/function/''')
   if neoinclude#util#is_mac()
     call neoinclude#util#set_default_dictionary(
           \ 'g:neoinclude#_ctags_arguments', 'c',


### PR DESCRIPTION
1. Avoid including function definitions twice.
2. Only include valid Vim function definitions.

Fixes #7. See example below.
