### PR TITLE
Fix bug that remain delimiter

### DIFF
--- a/autoload/neoinclude/file_include.vim
+++ b/autoload/neoinclude/file_include.vim
@@ -129,7 +129,7 @@ function! neoinclude#file_include#get_include_files(input) abort "{{{
 
     " Remove before delimiter.
     if delimiter != '' && strridx(dict.word, delimiter) >= 0
-      let dict.word = dict.word[strridx(dict.word, delimiter)+1: ]
+      let dict.word = dict.word[strridx(dict.word, delimiter)+strlen(delimiter): ]
     endif
 
     " Remove bufdirectory.


### PR DESCRIPTION
perl で noeinclude を使用するために、次のような設定をしてみたところ

``` vim
let g:neoinclude#delimiters.perl = '::'
```

delimiter の ':' が一つ残ったため修正してみました。よろしければ取り込んで頂けないでしょうか。よろしくお願いします。
