### PR TITLE
Fix bug that buffer local path is not used

### DIFF
--- a/autoload/neoinclude.vim
+++ b/autoload/neoinclude.vim
@@ -215,7 +215,7 @@ endfunction"}}}
 function! neoinclude#get_path(bufnr, filetype) abort "{{{
   " Don't use global path if it is not C or C++
   let default = (a:filetype ==# 'c' || a:filetype ==# 'cpp'
-        \ || getbufvar(a:bufnr, '&path') !=# &path) ?
+        \ || getbufvar(a:bufnr, '&path') !=# &g:path) ?
         \ getbufvar(a:bufnr, '&path') : '.'
   return neoinclude#util#substitute_path_separator(
         \ neoinclude#util#get_buffer_config(


### PR DESCRIPTION
perl で neoinclude を使用してみたころ 'path' の設定が使用されないため調べてみたところ、&path ではローカルな 'path' の値が返ってくるため 、getbufvar で返る値と同じで、ローカルな 'path' とグローバルの 'path' が異なる場合でも 'path' の値を使ってくれないようでしたので修正してみました。よろしければ取り込んで頂けないでしょうか。よろしくお願いします。
