### PR TITLE
Fix missing variable "command"

### DIFF
--- a/autoload/neoinclude/util.vim
+++ b/autoload/neoinclude/util.vim
@@ -116,7 +116,10 @@ function! neoinclude#util#system(command) abort "{{{
 
   return substitute(output, '\n$', '', '')
 endfunction"}}}
+
 function! neoinclude#util#async_system(command, is_force) abort "{{{
+  let command = s:iconv(a:command, &encoding, 'char')
+
   if a:is_force
     return neoinclude#util#system(command)
   elseif has('job')


### PR DESCRIPTION
This maintains the same safety guarantees as `neoinclude#util#system`, which from my quick glance seems warranted.