### PR TITLE
Fix ncm source error in python file

### DIFF
--- a/autoload/cm/sources/neoinclude.vim
+++ b/autoload/cm/sources/neoinclude.vim
@@ -11,7 +11,7 @@ function! cm#sources#neoinclude#refresh(opt, ctx) abort
 
   let inc = neoinclude#file_include#get_include_files(typed)
 
-  let matches = map(inc, "{'word': v:val['abbr'], 'dup': 1, 'icase': 1, 'menu': 'FI: ' . v:val['kind']}")
+  let matches = map(inc, "{'word': v:val['word'], 'dup': 1, 'icase': 1, 'menu': 'FI: ' . v:val['kind']}")
 
   call cm#complete(a:opt.name, a:ctx, startcol, matches)
 endfunction


### PR DESCRIPTION
Use 'word' instead of 'abbr'
'abbr' does not exist for python-jedi completion.